### PR TITLE
F2: lib-version(test the first version release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,7 @@ name: Release lib-version to GitHub Packages
 on:
   push:
     tags:
-      - 'v*'            # add a tag like v1.0.0 to trigger: when pushing such a tag(v1.0.0), this workflow runs
-
-permissions:
-  contents: read
-  packages: write
+      - 'v[0-9]+.[0-9]+.[0-9]+'  
 
 jobs:
   publish:
@@ -15,22 +11,21 @@ jobs:
 
     permissions:
       contents: read
-      packages: write 
+      packages: write
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-          server-id: github 
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
+          cache: 'maven'
+          server-id: github  
+          server-username: ${{ github.actor }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish to GitHub Packages
         run: mvn -B deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces the release workflow for the lib-version module and prepares the project for automated publishing to GitHub Packages as required in F2.

What this PR does:
Adds a release workflow (.github/workflows/release.yml) that is triggered when a Git tag following the format vX.Y.Z is pushed (e.g., v1.0.0).

Ensures that the artifact published to GitHub Packages uses the version defined in pom.xml as the single source of truth.

Updates the project version in pom.xml to 1.0.0 for the first release.

Important note:
The workflow triggers based on the Git tag, but the actual version of the published artifact always comes from pom.xml, not from the tag itself.
For example:
If pom.xml contains <version>1.0.0</version>,
But a developer pushes git tag v1.0.1,
then the workflow will still publish the artifact as version 1.0.0, because the tag only triggers the release — it does not determine the artifact’s version.

This behavior follows the project requirement that versioning must be maintained in project metadata, not derived from Git tags.